### PR TITLE
Gatsby Version Upgrade to 4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-starter-phantom
 
-Gatsby.js V2 starter template based on Phantom by HTML5 UP
+Gatsby.js V4 starter template based on Phantom by HTML5 UP
 
 For an overview of the project structure please refer to the [Gatsby documentation - Building with Components](https://www.gatsbyjs.org/docs/building-with-components/).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-phantom",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Gatsby.js V2 starter template based on Phantom by HTML5 UP",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-phantom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Gatsby.js V2 starter template based on Phantom by HTML5 UP",
   "repository": {
     "type": "git",
@@ -11,18 +11,22 @@
     "email": "anubhav.srivastava00@gmail.com"
   },
   "dependencies": {
-    "gatsby": "^2.20.2",
-    "gatsby-plugin-manifest": "^2.3.1",
-    "gatsby-plugin-offline": "^3.1.0",
-    "gatsby-plugin-react-helmet": "^3.2.0",
-    "gatsby-plugin-sass": "^2.2.0",
-    "node-sass": "^4.13.1",
+    "acorn": "^8.6.0",
+    "babel-eslint": "^10.1.0",
+    "gatsby": "^4.2.0",
+    "gatsby-plugin-manifest": "^4.2.0",
+    "gatsby-plugin-offline": "^5.2.0",
+    "gatsby-plugin-react-helmet": "^5.2.0",
+    "gatsby-plugin-sass": "^5.2.0",
+    "node-sass": "^6.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^5.2.1",
     "react-images": "^1.1.0",
     "react-scrollspy": "^3.4.2",
-    "smoothscroll-polyfill": "^0.4.4"
+    "sass": "^1.43.4",
+    "smoothscroll-polyfill": "^0.4.4",
+    "typescript": "^4.5.2"
   },
   "scripts": {
     "develop": "gatsby develop",
@@ -34,8 +38,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "gh-pages": "^2.0.1",
-    "prettier": "^1.17.0",
+    "gh-pages": "^3.2.3",
+    "prettier": "^2.4.1",
     "rimraf": "^3.0.2"
   },
   "keywords": [

--- a/src/assets/sass/base/_typography.scss
+++ b/src/assets/sass/base/_typography.scss
@@ -139,7 +139,7 @@
 		border-left: solid (_size(border-width) * 4) _palette(border);
 		font-style: italic;
 		margin: 0 0 _size(element-margin) 0;
-		padding: (_size(element-margin) / 4) 0 (_size(element-margin) / 4) _size(element-margin);
+		padding: (_size(element-margin) * 0.25) 0 (_size(element-margin) * 0.25) _size(element-margin);
 	}
 
 	code {

--- a/src/assets/sass/components/_form.scss
+++ b/src/assets/sass/components/_form.scss
@@ -6,7 +6,9 @@
 
 /* Form */
 
-	form {
+	@use "sass:math";
+
+form {
 		margin: 0 0 _size(element-margin) 0;
 		overflow-x: hidden;
 
@@ -33,7 +35,7 @@
 				}
 
 				&.third {
-					width: calc(#{100% / 3} - #{$gutter * (1 / 3)});
+					width: calc(#{100% / 3} - #{$gutter * math.div(1, 3)});
 				}
 
 				&.quarter {

--- a/src/assets/sass/components/_tiles.scss
+++ b/src/assets/sass/components/_tiles.scss
@@ -6,6 +6,8 @@
 
 /* Tiles */
 
+@use "sass:math";
+
 .tiles {
   $gutter: _size(gutter);
   $duration: 0.5s;
@@ -22,7 +24,7 @@
       ('transform #{$duration} #{$ease}', 'opacity #{$duration} #{$ease}')
     );
     position: relative;
-    width: calc(#{(100% / 3)} - #{$gutter * 1});
+    width: calc(#{math.div(100%, 3)} - #{$gutter * 1});
     margin: $gutter 0 0 $gutter;
 
     > .image {
@@ -225,7 +227,7 @@
     margin: ($gutter * -1) 0 0 ($gutter * -1);
 
     article {
-      width: calc(#{(100% / 3)} - #{$gutter * 1});
+      width: calc(#{math.div(100%, 3)} - #{$gutter * 1});
       margin: $gutter 0 0 $gutter;
     }
   }
@@ -236,7 +238,7 @@
     margin: ($gutter * -1) 0 0 ($gutter * -1);
 
     article {
-      width: calc(#{(100% / 2)} - #{$gutter * 1});
+      width: calc(#{(100% * 0.5)} - #{$gutter * 1});
       margin: $gutter 0 0 $gutter;
     }
   }
@@ -247,7 +249,7 @@
     margin: ($gutter * -1) 0 0 ($gutter * -1);
 
     article {
-      width: calc(#{(100% / 2)} - #{$gutter * 1});
+      width: calc(#{(100% * 0.5)} - #{$gutter * 1});
       margin: $gutter 0 0 $gutter;
 
       &:hover {

--- a/src/assets/sass/libs/_breakpoints.scss
+++ b/src/assets/sass/libs/_breakpoints.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: ();
 
 // Mixins.
 
@@ -41,7 +41,7 @@
 				}
 
 			// Less than or equal.
-				@elseif (str-slice($query, 0, 2) == '<=') {
+				@else if (str-slice($query, 0, 2) == '<=') {
 
 					$op: 'lte';
 					$breakpoint: str-slice($query, 3);
@@ -49,7 +49,7 @@
 				}
 
 			// Greater than.
-				@elseif (str-slice($query, 0, 1) == '>') {
+				@else if (str-slice($query, 0, 1) == '>') {
 
 					$op: 'gt';
 					$breakpoint: str-slice($query, 2);
@@ -57,7 +57,7 @@
 				}
 
 			// Less than.
-				@elseif (str-slice($query, 0, 1) == '<') {
+				@else if (str-slice($query, 0, 1) == '<') {
 
 					$op: 'lt';
 					$breakpoint: str-slice($query, 2);
@@ -65,7 +65,7 @@
 				}
 
 			// Not.
-				@elseif (str-slice($query, 0, 1) == '!') {
+				@else if (str-slice($query, 0, 1) == '!') {
 
 					$op: 'not';
 					$breakpoint: str-slice($query, 2);
@@ -100,22 +100,22 @@
 									}
 
 								// Less than or equal (<= y)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen and (max-width: ' + $y + ')';
 									}
 
 								// Greater than (> y)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
 								// Less than (< 0 / invalid)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: -1px)';
 									}
 
 								// Not (> y)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
@@ -135,22 +135,22 @@
 									}
 
 								// Less than or equal (<= inf / anything)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen';
 									}
 
 								// Greater than (> inf / invalid)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (max-width: -1px)';
 									}
 
 								// Less than (< x)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
 								// Not (< x)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
@@ -170,22 +170,22 @@
 									}
 
 								// Less than or equal (<= y)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen and (max-width: ' + $y + ')';
 									}
 
 								// Greater than (> y)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
 								// Less than (< x)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
 								// Not (< x and > y)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (max-width: ' + ($x - 1) + '), screen and (min-width: ' + ($y + 1) + ')';
 									}
 

--- a/src/assets/sass/libs/_html-grid.scss
+++ b/src/assets/sass/libs/_html-grid.scss
@@ -5,12 +5,14 @@
 	/// Initializes the current element as an HTML grid.
 	/// @param {mixed} $gutters Gutters (either a single number to set both column/row gutters, or a list to set them individually).
 	/// @param {mixed} $suffix Column class suffix (optional; either a single suffix or a list).
-	@mixin html-grid($gutters: 1.5em, $suffix: '') {
+	@use "sass:math";
+
+@mixin html-grid($gutters: 1.5em, $suffix: '') {
 
 		// Initialize.
 			$cols: 12;
 			$multipliers: 0, 0.25, 0.5, 1, 1.50, 2.00;
-			$unit: 100% / $cols;
+			$unit: math.div(100%, $cols);
 
 			// Suffixes.
 				$suffixes: null;

--- a/src/assets/sass/libs/_vendor.scss
+++ b/src/assets/sass/libs/_vendor.scss
@@ -362,7 +362,7 @@
 			}
 
 		// Expand just the value?
-			@elseif $expandValue {
+			@else if $expandValue {
 			    @each $vendor in $vendor-prefixes {
 			        #{$property}: #{str-replace-all($value, '-prefix-', $vendor)};
 			    }


### PR DESCRIPTION
Updated Gatsby Version to 4.2.0 to enable support for the latest version of Gatsby.

Updated additional package versions to address peer dependencies flagged by NPM.

This PR does NOT address the Sass warnings added by the Sass version update.  Running a development build will show the full list of Sass warnings.